### PR TITLE
fix(layout): corrigir alinhamento de cards no mobile e desktop

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -49,11 +49,11 @@ const AdminDashboard = () => {
     <div className="w-full min-h-screen flex flex-col p-4">
       <TopBar title="Painel Administrativo" isAdmin={true} />
 
-      <div className="flex flex-col md:flex-row w-full justify-center gap-6 mt-6 px-6">
-        <div className="max-w-md w-full">
+      <div className="flex flex-col md:flex-row w-full justify-center items-center md:items-start gap-6 mt-6 px-6">
+        <div className="max-w-md w-full flex flex-col items-center md:items-start">
           <ControleVotacao votacaoLiberada={votacaoLiberada} onToggleVotacao={toggleVotacao} />
         </div>
-        <div className="max-w-md w-full">
+        <div className="max-w-md w-full flex flex-col items-center md:items-start">
           <AddJogadorForm
             nome={nome}
             assistencias={assistencias}


### PR DESCRIPTION
### 📌 O que foi corrigido?
- Ajustado `justify-center` e `items-center` para garantir que os cards fiquem **alinhados corretamente no desktop** e **centralizados no mobile**.
- Mantida a estrutura flexível para funcionar em diferentes tamanhos de tela.

### ✅ Como testar?
1️⃣ **Verifique no desktop** se os componentes estão alinhados lado a lado.  
2️⃣ **No mobile**, os componentes devem ficar um abaixo do outro e **centralizados**.

### 📂 Branch relacionada
- `fix-alinhamento-cards`

### 🔗 Commits relacionados
- `fix(layout): corrigir alinhamento de cards no mobile e desktop`

🚀 **PR pronto para revisão!**  